### PR TITLE
Add ppc64le arch (WIP)

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,6 @@
 FROM ubuntu:16.04
 # FROM arm=armhf/ubuntu:16.04
+# FROM ppc64le/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
@@ -8,14 +9,16 @@ RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_ppc64le=ppc64le \
+    GOLANG_ARCH=GOLANG_ARCH_${ARCH} GOPATH=/go \
+    PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+    DOCKER_URL_ppc64le=https://github.com/zambon/moby/releases/download/v1.10.3/docker-1.10.3_ppc64le \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,12 +1,12 @@
-FROM ubuntu:16.04
-# FROM arm=armhf/ubuntu:16.04
-# FROM ppc64le/ubuntu:16.04
+FROM zambon/ubuntu-multi:16.04
+# FROM arm=armhf/ubuntu:16.04 ppc64le=ppc64le/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file && \
+RUN apt-get -q update && \
+    apt-get -qy install gcc ca-certificates git wget curl vim less file && \
+    rm -rf /var/lib/apt/lists/* && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_ppc64le=ppc64le \

--- a/scripts/build
+++ b/scripts/build
@@ -7,4 +7,6 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS -linkmode external -extldflags -static -s" -o bin/share-mnt
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS -linkmode external -extldflags -static -s" -o bin/share-mnt-`uname -s`-`uname -m`
+[ -L bin/share-mnt ] && unlink bin/share-mnt
+ln -s bin/share-mnt-`uname -s`-`uname -m` bin/share-mnt

--- a/scripts/build
+++ b/scripts/build
@@ -9,4 +9,4 @@ mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
 CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS -linkmode external -extldflags -static -s" -o bin/share-mnt-`uname -s`-`uname -m`
 [ -L bin/share-mnt ] && unlink bin/share-mnt
-ln -s bin/share-mnt-`uname -s`-`uname -m` bin/share-mnt
+ln -s share-mnt-`uname -s`-`uname -m` bin/share-mnt

--- a/scripts/package
+++ b/scripts/package
@@ -16,6 +16,6 @@ if echo $TAG | grep -q dirty; then
     TAG=dev
 fi
 
-tar cvzf share-mnt-`uname -s`-`uname -m`.tar.gz -C ../bin share-mnt
+tar cvzfh share-mnt-`uname -s`-`uname -m`.tar.gz -C ../bin share-mnt
 
-echo Created share-mnt.tar.gz
+echo Created share-mnt-`uname -s`-`uname -m`.tar.gz

--- a/scripts/package
+++ b/scripts/package
@@ -16,6 +16,6 @@ if echo $TAG | grep -q dirty; then
     TAG=dev
 fi
 
-tar cvzf share-mnt.tar.gz -C ../bin share-mnt
+tar cvzf share-mnt-`uname -s`-`uname -m`.tar.gz -C ../bin share-mnt
 
 echo Created share-mnt.tar.gz


### PR DESCRIPTION
#Adds support for Power.

This depends on Dapper's [PR 44](https://github.com/rancher/dapper/pull/44).

I downloaded Docker 1.10.3 for ppc64le from the [Ubuntu repository](http://ports.ubuntu.com/ubuntu-ports/pool/universe/d/docker.io/), and extracted the client binary from it (and renamed to `docker-1.10.3_ppc64le`).

_**EDIT:** The binary above is dynamically linked and doesn't work reliably. Trying to build it myself._

I'm not sure if `share-mnt` requires a special build of it; either way, the file should probably be hosted in [rancher/docker@v1.10.3](https://github.com/rancher/docker/releases/tag/v1.10.3-ros1). Let me know if I should update that.