### PR TITLE
Fix segmentation fault issue

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -6,5 +6,5 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS -linkmode external -extldflags -static -s" -o bin/share-mnt
+[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode internal -extldflags -static -s"
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/share-mnt


### PR DESCRIPTION
The AMD64 architecture binaries result in a segmentation fault. Changing the link mode to internal to get around segmentation fault for binaries created in ubuntu or Debian.

See https://github.com/rancher/rancher/issues/20740

**Another option:**
I did get external linkage to work,  but by using go 1.11.10 alpine container instead of using ubuntu 16. On ubuntu, it just won't work even after trying multiple options.