### PR TITLE
Remove linkmode=external to avoid breakpoint/trap

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -6,5 +6,5 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS -linkmode external -extldflags -static -s" -o bin/share-mnt
+[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/share-mnt


### PR DESCRIPTION
This is the same fix as applied to rke-tools in https://github.com/rancher/rke-tools/pull/68

https://github.com/rancher/rancher/issues/20740