### PR TITLE
Remove linkmode=external to avoid breakpoint/trap

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,7 +11,7 @@ RUN apt-get update && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.13.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get golang.org/x/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \

--- a/main.go
+++ b/main.go
@@ -19,11 +19,9 @@ import (
 	"github.com/docker/docker/pkg/mount"
 )
 
-const (
-	version = "0.0.0"
-)
-
 var (
+	// VERSION gets overridden at build time using -X main.VERSION=$VERSION
+	VERSION       = "dev"
 	cgroupPattern = regexp.MustCompile("^.*/docker-([a-z0-9]+).scope$")
 	// Add the statepath as found on most OS's, and prefix with '/var' for Boot2Docker
 	statePaths = []string{
@@ -40,7 +38,7 @@ var (
 
 func main() {
 	app := cli.NewApp()
-	app.Version = version
+	app.Version = VERSION
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name: "stage2",

--- a/scripts/build
+++ b/scripts/build
@@ -6,5 +6,5 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS -linkmode external -extldflags -static -s" -o bin/share-mnt
+[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS -extldflags -static -s" -o bin/share-mnt


### PR DESCRIPTION
This is the same fix as applied to rke-tools in https://github.com/rancher/rke-tools/pull/68

Also upgrades Golang to 1.13.4 like Rancher and RKE, and fixes the `--version` to show the actual version

https://github.com/rancher/rancher/issues/20740